### PR TITLE
Added installation instructions for writexl

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ You can install the package from github with:
 
 ``` r
 # install.packages("devtools")
+# devtools::install_github("ropensci/writexl")
+# mschart depends on writexl which is provided by ropensci
 devtools::install_github("ardata-fr/mschart")
 ```
 


### PR DESCRIPTION
Since writexl isn't available on CRAN but the current code for mschart depends on it, I added the installation instructions (to save others googling effort).