### PR TITLE
Smoothed series

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: mschart
 Type: Package
 Title: Chart Generation for 'Microsoft Word' and 'Microsoft PowerPoint' Documents
 Version: 0.2.4.001
-Authors@R: c( person("David", "Gohel", role = c("aut", "cre"), email = "david.gohel@ardata.fr"), person("YouGov", role = "fnd") )
+person("David", "Gohel", role = c("aut", "cre"), email = "david.gohel@ardata.fr"),person("YouGov", role = "fnd"),person("David", "Camposeco", role = "ctb", email = "david.camposeco.paulsen@gmail.com") )
 Description: Create native charts for 'Microsoft PowerPoint' and 'Microsoft Word' documents. 
  These can then be edited and annotated. Functions are provided to let users create charts, modify 
  and format their content. The chart's underlying data is automatically saved within the 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: mschart
 Type: Package
 Title: Chart Generation for 'Microsoft Word' and 'Microsoft PowerPoint' Documents
 Version: 0.2.4.001
-person("David", "Gohel", role = c("aut", "cre"), email = "david.gohel@ardata.fr"),person("YouGov", role = "fnd"),person("David", "Camposeco", role = "ctb", email = "david.camposeco.paulsen@gmail.com") )
+Authors@R: person("David", "Gohel", role = c("aut", "cre"), email = "david.gohel@ardata.fr"),person("YouGov", role = "fnd"),person("David", "Camposeco", role = "ctb", email = "david.camposeco.paulsen@gmail.com") )
 Description: Create native charts for 'Microsoft PowerPoint' and 'Microsoft Word' documents. 
  These can then be edited and annotated. Functions are provided to let users create charts, modify 
  and format their content. The chart's underlying data is automatically saved within the 

--- a/R/chart_data_color.R
+++ b/R/chart_data_color.R
@@ -236,7 +236,40 @@ chart_data_line_width <- function(x, values){
   x
 }
 
+#' @export
+#' @title Smooth series
+#' @description Specify mappings from levels in the data to displayed symbols.
+#' @param x an \code{ms_chart} object.
+#' @param values  `integer(num of series)`: a set of smooth values to map data values to.
+#' It is a named vector, the values will be matched based on the names.
+#' Possible values are 0 or 1
+#' If it contains only one integer it will be associated to all existing series.
+#' @examples
+#' linec <- ms_linechart(data = iris, x = "Sepal.Length",
+#'   y = "Sepal.Width", group = "Species")
+#'linec <- chart_data_smooth(linec,
+#'   values = c(virginica = 0, versicolor = 0, setosa = 0) )
+#' @seealso \code{\link{chart_data_fill}}, \code{\link{chart_data_stroke}}, \code{\link{chart_data_size}}
+chart_data_smooth <- function(x, values){
+  as_bool <- c(1,0)
 
+  if( !all(values %in% as_bool) ){
+    stop("smooth can only take values of 0 or 1")
+  }
+
+  serie_names <- names(x$series_settings$symbol)
+
+  if( length(values) == 1 ){
+    values <- rep(values, length(serie_names))
+    names(values) <- serie_names
+  }
+
+  if( !all(names(values) %in% serie_names ) )
+    stop( "values's names do not match series' names: ", paste0(shQuote(serie_names), collapse = ", "))
+
+  x$series_settings$smooth[names(values)] <- values
+  x
+}
 
 #' chart_labels_colors <- function(x, values){
 #'

--- a/R/ms_chart.R
+++ b/R/ms_chart.R
@@ -53,13 +53,15 @@ ms_chart <- function(data, x, y, group = NULL){
   series_size <- rep(12, length(series_names) )
   series_lwidth <- rep(2, length(series_names) )
   labels_fp <- rep(list(fp_text(font.size = 0)), length(series_names) )
+  series_smooth <- rep(1,length(series_names))
   out$series_settings <- list(
     fill = setNames(palette_, series_names),
     colour = setNames(palette_, series_names),
     symbol = setNames(series_symbols, series_names),
     size = setNames(series_size, series_names),
     line_width = setNames(series_lwidth, series_names),
-    labels_fp = setNames(labels_fp, series_names)
+    labels_fp = setNames(labels_fp, series_names),
+    smooth = setNames(series_smooth, series_names)
     )
   out
 }

--- a/R/ooml_code.R
+++ b/R/ooml_code.R
@@ -67,7 +67,7 @@ ooml_code.ms_linechart <- function(x, id_x, id_y, sheetname = "sheet1"){
 
   template_str <- paste0("<c:ser><c:idx val=\"%.0f\"/><c:order val=\"%.0f\"/><c:tx>%s</c:tx>%s%s%s",
                      "<c:cat>%s</c:cat>",
-                     "<c:val>%s</c:val></c:ser>")
+                     "<c:val>%s</c:val><c:smooth val=\"%.0f\"/></c:ser>")
   series <- as_series(x, x_class = serie_builtin_class(x$data[[x$x]]),
                       y_class = serie_builtin_class(x$data[[x$y]]), sheetname = sheetname )
   str_series_ <- sapply( series, function(serie, template ){
@@ -81,7 +81,7 @@ ooml_code.ms_linechart <- function(x, id_x, id_y, sheetname = "sheet1"){
 
     sprintf(template, serie$idx, serie$order, serie$tx$pml(), sppr_str, marker_str,
             labels_ooxml,
-            serie$x$pml(), serie$y$pml() )
+            serie$x$pml(), serie$y$pml(), serie$smooth )
   }, template = template_str)
   str_series_ <- paste(str_series_, collapse = "")
 

--- a/R/series.R
+++ b/R/series.R
@@ -107,7 +107,8 @@ as_series <- function(x, x_class, y_class, sheetname = "sheet1" ){
                  symbol = x$series_settings$symbol[y_colname],
                  size = x$series_settings$size[y_colname],
                  line_width = x$series_settings$line_width[y_colname],
-                 labels_fp = x$series_settings$labels_fp[[y_colname]]
+                 labels_fp = x$series_settings$labels_fp[[y_colname]],
+                 smooth = x$series_settings$smooth[y_colname]
                  )
     series <- append(series, list(ser) )
   }

--- a/vignettes/details.Rmd
+++ b/vignettes/details.Rmd
@@ -130,6 +130,15 @@ gen_pptx(lc_02, file = "assets/pptx/gallery_line_02.pptx")
 lc_03 <- chart_settings(lc_02, grouping = "percentStacked")
 gen_pptx(lc_03, file = "assets/pptx/gallery_line_03.pptx")
 ```
+#### Smoothed lines
+
+```{r}
+linec <- ms_linechart(data = iris, x = "Sepal.Length",
+                      y = "Sepal.Width", group = "Species")
+linec_smooth <- chart_data_smooth(linec,
+                values = c(virginica = 1, versicolor = 0, setosa = 0) )
+gen_pptx(linec_smooth, file = "assets/pptx/gallery_line_04.pptx")
+```
 
 ### Area chats
 


### PR DESCRIPTION
Modifies the `ms_chart` object whenever created by the `ms_linechart` function to include a `$smooth` value (default=1) in the` $series_settings` of the object. It also modifies the `series` object generated by the `as_series ` function to return a `smooth` value which it inherits from the one generated by the` ms_linechart`  function. Finally it modifies the xml template associated to line charts in the `ooml_code.ms_linechart` function to include the `<c:smooth val="INTEGER"\>`  tag inserting the property generated by `as_series`. I wrote a simple  `chart_data_smooth` function (and a short documentation) to control the smoothing parameter of each series. 