### PR TITLE
Better scatter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Imports: stats, data.table,
  htmltools
 URL: https://ardata-fr.github.io/mschart/
 BugReports: https://github.com/ardata-fr/mschart/issues
-RoxygenNote: 7.0.0
+RoxygenNote: 7.1.1
 Suggests: knitr,
     rmarkdown,magrittr
 VignetteBuilder: knitr

--- a/R/utils.R
+++ b/R/utils.R
@@ -16,6 +16,9 @@ shape_as_series <- function(x){
 
 #' @importFrom data.table as.data.table
 groupify_data <- function(x, dataset) {
+  # This function relies on a grouop being defined
+  stopifnot(!is.null(x$group))
+
   # This weird looking line is designed to resolve the notes that get generated
   # during devtools::check() because .N and := aren't explicitly made visible
   `:=` <- .N <- NULL

--- a/man/browser_data.Rd
+++ b/man/browser_data.Rd
@@ -4,7 +4,9 @@
 \name{browser_data}
 \alias{browser_data}
 \title{Dummy dataset for barchart}
-\format{A data frame with 18 rows and 3 variables}
+\format{
+A data frame with 18 rows and 3 variables
+}
 \usage{
 data(browser_data)
 }

--- a/man/browser_ts.Rd
+++ b/man/browser_ts.Rd
@@ -4,7 +4,9 @@
 \name{browser_ts}
 \alias{browser_ts}
 \title{Dummy dataset for barchart}
-\format{A data frame with 36 rows and 3 variables}
+\format{
+A data frame with 36 rows and 3 variables
+}
 \usage{
 data(browser_ts)
 }

--- a/man/chart_ax_x.Rd
+++ b/man/chart_ax_x.Rd
@@ -156,7 +156,7 @@ effect.
 \item \verb{[h]:mm:ss}
 \item \code{mmss.0}
 \item \verb{##0.0E+0}
-\item \verb{@}
+\item \code{@}
 }
 }
 


### PR DESCRIPTION
Currently, the function `shape_as_series` in `utils.R` will only select a single y value per x and group value pair:
https://github.com/ardata-fr/mschart/blob/11d0e91d083da62c0bf88022e932c9bab3896f0e/R/utils.R#L7-L15

In a situation where there are multiple y values for each x value this can produce undesirable results, as seen here:
<img width="512" alt="current-behaviour" src="https://user-images.githubusercontent.com/349164/100759774-ec034a80-33e8-11eb-98f6-92b509156c82.png">

When instead we would rather have multiple y values per x value, and get this result:
<img width="512" alt="desired-behaviour" src="https://user-images.githubusercontent.com/349164/100759779-ed347780-33e8-11eb-90df-3a1bc299f945.png">

This will require a change in the `shape_as_series` function to allow for these multiple y values. The dcast is a little tricky but I have implemented it in utils.R as `groupify_data`:

https://github.com/danjoplin/mschart/blob/1cb1cb6f58183a536141de321639112e01d56ef9/R/utils.R#L6-L12

https://github.com/danjoplin/mschart/blob/1cb1cb6f58183a536141de321639112e01d56ef9/R/utils.R#L18-L37

It might be that this change could have an effect on other plot behaviours but I haven't seen it cause any problems.