### PR TITLE
Return single value in `dcast.data.table()`. Required in `data.table` > 1.5. Fixes #94

### DIFF
--- a/R/excel_series.R
+++ b/R/excel_series.R
@@ -64,7 +64,7 @@ dcast_data <- function(data, x, y, group) {
     dataset,
     formula = as.formula(form_str),
     fun.aggregate = function(x) {
-      x
+      x[length(x)]
     },
     fill = NA, value.var = y
   )


### PR DESCRIPTION
This fixes outstanding issue #94 (since this is a reported revdep issue, CRAN might start throwing errors for `mschart` soon). I've tested it (only) with 
```r
ms_linechart(data = iris, x = "Sepal.Length", y = "Sepal.Width", group = "Species")
``` 
using `data.table` from CRAN and github and for the latter can confirm the problem with the current CRAN release of `mschart`.

As mentioned before, I'm not necessarily the biggest fan of the underlying aggregation function, though I did look at it for a moment longer than necessary. Mainly to find out what is actually going on. Below is a small sample data set. This shows that `mschart` matches `gpplot2`.

Unfortunately, both silently ignore variations in the grouping variable. I would have preferred it if - especially in cases where there is a significant deviation in the grouping value - the console would flash up with warnings and/or the aggregation function would default to something like the mean or median.

``` r
dat <- data.frame(
  orders  = c(1, 1, 5, 2, 9),
  expense = c(50e6, 50, 50e6, 4, 5),
  sales   = c(1000, 1000, 50, 500, 700)
)

library(mschart)
scatter <-
  ms_scatterchart(
    data = dat, x = "orders",
    y = "sales", group = "expense"
  )
scatter <- chart_settings(scatter, scatterstyle = "marker")

library(officer)
doc <- read_pptx()
doc <- add_slide(doc, layout = "Title and Content", master = "Office Theme")
doc <- ph_with(doc, value = scatter, location = ph_location_fullsize())

print(doc, target = "example.pptx")

system("soffice example.pptx &")
# unlink("example.pptx")

library(ggplot2)
ggplot(dat, aes(x = orders, y = sales, group = expense, col = expense)) +
  geom_point()
```

![](https://i.imgur.com/TXLD70e.png)<!-- -->

![Screenshot_2024-04-14_16-20-33](https://github.com/ardata-fr/mschart/assets/1645626/c94e529e-d404-44a9-8cfb-494a2ce43f9b)


