### PR TITLE
Fix. Account for line style = "none". Closes #91.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,6 +40,6 @@ Imports:
     scales
 URL: https://ardata-fr.github.io/officeverse/, https://ardata-fr.github.io/mschart/
 BugReports: https://github.com/ardata-fr/mschart/issues
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Roxygen: list(markdown = TRUE)
 Suggests: tinytest, doconv

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Issues
 
 * fix issue with dcast by making sure all data are preserved.
+* Fix. Account for "none" linestyle set via `chart_data_line_style`. Closes #91.
 
 ## New features
 

--- a/R/to_pml.R
+++ b/R/to_pml.R
@@ -81,7 +81,7 @@ to_pml.ms_linechart <- function(x, id_x, id_y, sheetname = "sheet1", add_ns = FA
       line_str <- "<c:spPr><a:ln><a:noFill/></a:ln></c:spPr>"
     } else {
       line_properties <- fp_border(color = serie$stroke, style = serie$line_style, width = serie$line_width)
-      line_str <- ooxml_fp_border(line_properties, in_tags = c("c:spPr"))
+      line_str <- ooxml_fp_border(line_properties, in_tags = c("c:spPr"), none_as_empty = FALSE)
     }
     if( !has_marker )
       marker_str <- "<c:marker><c:symbol val=\"none\"/></c:marker>"

--- a/R/utils.R
+++ b/R/utils.R
@@ -40,16 +40,29 @@ pretty_num_axes <- function(x, data_x, data_y){
   x
 }
 
+wrap_in_tags <- function(out, in_tags = NULL) {
+  if( !is.null(in_tags) ){
+    begin <- paste0("<", in_tags, ">", collapse = "")
+    end <- paste0("</", rev(in_tags), ">", collapse = "")
+    out <- paste0(begin, out, end)
+  }
+  out
+}
+
 #' @importFrom grDevices rgb
-ooxml_fp_border <- function(x, in_tags = NULL ){
+ooxml_fp_border <- function(x, in_tags = NULL, none_as_empty = TRUE ){
   stopifnot(inherits(x, "fp_border"))
   colspecs <- as.list(col2rgb( x$color, alpha = TRUE )[,1] / 255)
 
   alpha <- colspecs$alpha
   is_transparent <- alpha < .0001
 
-  if( is_transparent || x$width < 0.001 || x$style %in% "none" ){
-    return("")
+  if( is_transparent || x$width < 0.001 || x$style %in% "none" ) {
+    if (none_as_empty) {
+      return("")
+    } else {
+      return(wrap_in_tags("<a:ln><a:noFill/></a:ln>", in_tags = in_tags))
+    }
   }
 
   colspecs$alpha <- NULL
@@ -71,12 +84,7 @@ ooxml_fp_border <- function(x, in_tags = NULL ){
   out <- sprintf("<a:ln algn=\"ctr\" w=\"%.0f\">", x$width * 12700)
   out <- paste0(out, solidfill, presetdash, "</a:ln>")
 
-  if( !is.null(in_tags) ){
-    begin <- paste0("<", in_tags, ">", collapse = "")
-    end <- paste0("</", rev(in_tags), ">", collapse = "")
-    out <- paste0(begin, out, end)
-  }
-  out
+  wrap_in_tags(out, in_tags = in_tags)
 }
 
 

--- a/inst/tinytest/test_linechart.R
+++ b/inst/tinytest/test_linechart.R
@@ -31,3 +31,36 @@ names(smooth_data) <- serie_names
 smooth_data <- smooth_data[order(names(smooth_data))]
 
 expect_equivalent(settings, smooth_data)
+
+# Accounts for style="none" ----
+lty <- c(green = "none", unclear = "solid", gray = "dotted")
+lty <- lty[order(names(lty))]
+
+chart_02 <- ms_linechart(data = dat, x = "musician", y = "count", group = "color")
+chart_02 <- chart_data_line_style(chart_02, values = lty)
+
+xml <- format(
+  chart_02,
+  sheetname = "sheet1",
+  id_x = "64451212",
+  id_y = "64453248"
+)
+
+chart <- read_xml(xml)
+
+lines <- xml_find_all(chart, "//c:ser/c:spPr/a:ln")
+
+# Has "noFill" node for "none", "solidFill" otherwise
+lookup_fill <- c(none = "noFill", solid = "solidFill", dashed = "solidFill", dotted = "solidFill")
+node_fill <- xml_find_all(chart, "//c:ser/c:spPr/a:ln/a:noFill|//c:ser/c:spPr/a:ln/a:solidFill")
+node_fill <- xml_name(node_fill)
+expect_equal(node_fill, unname(lookup_fill[lty]))
+
+# "prstDash" has correct "val" attribute
+lookup_lty <- c(none = NA, solid = "solid", dashed = "sysDash", dotted = "sysDot")
+attr_lty <- vapply(
+  lines,
+  function(x) xml_attr(xml_find_first(x, "a:prstDash"), "val"),
+  FUN.VALUE = character(1)
+)
+expect_equal(attr_lty, unname(lookup_lty[lty]))


### PR DESCRIPTION
Hi David and Eli,

just in case you find the time. This PR proposes a fix for - the not very well reported - issue #91 .

Using the current CRAN and dev version setting the line style in a `ms_linechart` to `"none"` via `chart_data_line_style` does not work. Instead we get a solid line with the default settings for color, ....:

```
library(mschart)
library(officer)

dat <- data.frame(
  color = c(rep("green", 3), rep("unclear", 3), rep("gray", 3)),
  musician = c(rep(c("Robert Wyatt", "John Zorn", "Damon Albarn"), 3)),
  count = c(120, 101, 131, 200, 154, 187, 122, 197, 159),
  stringsAsFactors = FALSE
)

lty <- c(green = "none", unclear = "dashed", gray = "none")
lty <- lty[order(names(lty))]

chart <- ms_linechart(data = dat, x = "musician", y = "count", group = "color")
chart <- chart_data_line_style(chart, values = lty)

file <- tempfile(fileext = ".pptx")
doc <- read_pptx()
doc <- add_slide(doc, layout = "Title and Content", master = "Office Theme")
doc <- ph_with(doc, value = chart, location = ph_location_fullsize())
print(doc, target = file)

# doconv::to_miniature(file, fileout = "issue-91.png")
```

![image](https://github.com/user-attachments/assets/8856a223-8113-483c-a938-9349b412f08e)

The issue is that currently an empty string is "added" for lines with a "none" style:
https://github.com/ardata-fr/mschart/blob/b69fbf62402e701e4373834faa0f32da2a67099e/R/utils.R#L51-L53
instead of the required `"<c:spPr><a:ln><a:noFill/></a:ln></c:spPr>"` as is already done in 
https://github.com/ardata-fr/mschart/blob/b69fbf62402e701e4373834faa0f32da2a67099e/R/to_pml.R#L81
when the style of the linechart is set globally using e.g. `chart_settings(x, style = "marker")`.

The proposed fix adds a `none_as_empty` argument to `ooxml_fp_border` so that one can choose between having an empty string (where this is fine) or a `<a:ln><a:noFill/></a:ln>` for a "none" style.

Using the proposed fix we get the correct result:

![image](https://github.com/user-attachments/assets/d4cbdf44-4ebf-48ee-9ee9-273ca700a775)
